### PR TITLE
hard-code doc deploy process

### DIFF
--- a/tools/gh-pages-publish.ts
+++ b/tools/gh-pages-publish.ts
@@ -1,31 +1,14 @@
-const { cd, exec, echo, touch } = require("shelljs")
-const { readFileSync } = require("fs")
-const url = require("url")
+const { cd, exec, echo, touch } = require("shelljs");
 
-let repoUrl
-let pkg = JSON.parse(readFileSync("package.json") as any)
-if (typeof pkg.repository === "object") {
-  if (!pkg.repository.hasOwnProperty("url")) {
-    throw new Error("URL does not exist in repository section")
-  }
-  repoUrl = pkg.repository.url
-} else {
-  repoUrl = pkg.repository
-}
-
-let parsedUrl = url.parse(repoUrl)
-let repository = (parsedUrl.host || "") + (parsedUrl.path || "")
-let ghToken = process.env.GH_TOKEN
-
-echo("Deploying docs!!!")
-cd("docs")
-touch(".nojekyll")
-exec("git init")
-exec("git add .")
-exec('git config user.name "Ian"')
-exec('git config user.email "iwburns8@gmail.com"')
-exec('git commit -m "docs(docs): update gh-pages"')
+echo("Deploying docs!!!");
+cd("docs");
+touch(".nojekyll");
+exec("git init");
+exec("git add .");
+exec('git config user.name "Ian"');
+exec('git config user.email "iwburns8@gmail.com"');
+exec('git commit -m "docs(docs): update gh-pages"');
 exec(
-  `git push --force --quiet "https://${ghToken}@${repository}" master:gh-pages`
-)
-echo("Docs deployed!!")
+  `git push --force --quiet git@github.com:iwburns/tupperware.git master:gh-pages`
+);
+echo("Docs deployed!!");


### PR DESCRIPTION
Travis is no longer going to build the docs for us, so all of this
configuration isn't really necessary.  I left this in a TS script
because it's (I assume) more cross-platform than a bash script.